### PR TITLE
rake task doesn't work

### DIFF
--- a/lib/tasks/slosilo.rake
+++ b/lib/tasks/slosilo.rake
@@ -21,7 +21,7 @@ namespace :slosilo do
   end
 
   desc "Migrate to a new database schema"
-  task :migrate, :environment do |t|
-    Slosilo.keystore.migrate!
+  task :migrate => :environment do |t|
+    Slosilo.adapter.migrate!
   end
 end


### PR DESCRIPTION
Still getting an error though, this is from authz:

localhost:authz kgilpin$ rake slosilo:migrate -b
rake aborted!
No database associated with Sequel::Model: have you called Sequel.connect or Sequel::Model.db= ?
/Users/kgilpin/.rvm/gems/ruby-2.0.0-p195@authz/gems/sequel-3.48.0/lib/sequel/model/base.rb:246:in `db'
/Users/kgilpin/.rvm/gems/ruby-2.0.0-p195@authz/gems/sequel-3.48.0/lib/sequel/model/base.rb:245:in`db'
/Users/kgilpin/.rvm/gems/ruby-2.0.0-p195@authz/gems/sequel-3.48.0/lib/sequel/model/base.rb:550:in `set_dataset'
/Users/kgilpin/.rvm/gems/ruby-2.0.0-p195@authz/gems/sequel-3.48.0/lib/sequel/model.rb:46:in`Model'
/Users/kgilpin/source/inscitiv/slosilo/lib/slosilo/adapters/sequel_adapter.rb:11:in `create_model'
/Users/kgilpin/source/inscitiv/slosilo/lib/slosilo/adapters/sequel_adapter.rb:7:in`model'
/Users/kgilpin/source/inscitiv/slosilo/lib/slosilo/adapters/sequel_adapter.rb:71:in `fingerprint_in_db?'
/Users/kgilpin/source/inscitiv/slosilo/lib/slosilo/adapters/sequel_adapter.rb:47:in`migrate!'
/Users/kgilpin/source/inscitiv/slosilo/lib/tasks/slosilo.rake:25:in `block (2 levels) in <top (required)>'
