### PR TITLE
Add an "expiration" field to tokens from #signed_token.

### DIFF
--- a/lib/slosilo/http_request.rb
+++ b/lib/slosilo/http_request.rb
@@ -26,7 +26,11 @@ module Slosilo
     # Sign the request with :own key from Slosilo::Keystore. 
     # If calling this manually, make sure to encrypt before signing.
     def sign!
-      token = Slosilo[:own].signed_token signed_data
+      # Hmm, I'm not sure whether we should update this to include an expiration
+      # in a header, or just continue to leave out the expiration field.  Leaving it
+      # out requires fewer changes (to Slosilo::Rack::MiddleWare) so I'm going with 
+      # that for now.
+      token = Slosilo[:own].signed_token signed_data, expiration: false
       self['Timestamp'] = token["timestamp"]
       self['X-Slosilo-Signature'] = token["signature"]
     end

--- a/lib/slosilo/key.rb
+++ b/lib/slosilo/key.rb
@@ -64,9 +64,25 @@ module Slosilo
       false
     end
 
-    # create a new timestamped and signed token carrying data
-    def signed_token data
-      token = { "data" => data, "timestamp" => Time.new.utc.to_s }
+    # create a new timestamped and signed token carrying data.
+    # 
+    # @param [anything] data data to include in the signed token
+    # @param [Hash,nil] options for the signature
+    # @option options [see below] :expiration 
+    #   Specifies whether to include an `"expiration"` field, and what it's value should be.
+    #   The value may be one of:
+    #     * `nil`, `true`: Include a default expiration (currently 8 minutes from now).
+    #     * `Time`: Set the expiration field to this value
+    #     * `Numeric`: Set the token to expire in this many seconds
+    #     * `false`: Do not include an expiration field (this is only to support legacy code,
+    #         and should not be used for new applications).
+    def signed_token data, options = {}
+      timestamp, expiration = token_time_fields options
+      token = { 
+        "data" => data,   
+        "timestamp" => timestamp.to_s
+      }
+      token["expiration"] = expiration.to_s if expiration
       token["signature"] = Base64::urlsafe_encode64(sign token)
       token["key"] = fingerprint
       token
@@ -77,7 +93,18 @@ module Slosilo
       expected_key = token.delete "key"
       return false if (expected_key and (expected_key != fingerprint))
       signature = Base64::urlsafe_decode64(token.delete "signature")
-      (Time.parse(token["timestamp"]) + expiry > Time.now) && verify_signature(token, signature)
+      !token_expired?(token, expiry) && verify_signature(token, signature)
+    end
+    
+    # Check whether a token is expired, using it's expiration field if present,
+    # or the timestamp + :expiry:
+    def token_expired? token, expiry = 8 * 60
+      if expiration = token["expiration"]
+        expiration = Time.parse expiration
+      else
+        expiration = Time.parse(token["timestamp"]) + expiry
+      end
+      expiration < current_time
     end
     
     def sign_string value
@@ -117,6 +144,26 @@ module Slosilo
     
     def hash_function
       @hash_function ||= OpenSSL::Digest::SHA256
+    end
+    
+    def token_time_fields options
+      timestamp = current_time
+      expiration = case expiration = options[:expiration]
+        when FalseClass then nil
+        when NilClass, TrueClass then timestamp + 8 * 60
+        when Numeric then timestamp + expiration
+        when Time then expiration.utc
+        else raise ArgumentError, "expiration must be Time or Numeric (was #{expiration} of #{expiration.class})" 
+      end
+      raise ArgumentError, "Cowardly: refusing to generate already expired token!" if expiration && expiration < timestamp
+      [timestamp, expiration]
+    end
+    
+    # Provides a simple way for tests to change the time used
+    # when generating and validating tokens.  Use this instead of
+    # Time.new/Time.now
+    def current_time
+      Time.new.utc
     end
   end
 end

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -20,7 +20,7 @@ describe Slosilo::HTTPRequest do
     let(:token) { { "data" => signed_data, "timestamp" => timestamp, "signature" => signature } }
     
     it "makes a token out of the data to sign and inserts headers" do
-      own_key.stub(:signed_token).with(signed_data).and_return token
+      own_key.stub(:signed_token).with(signed_data, expiration: false).and_return token
       subject.should_receive(:[]=).with 'Timestamp', timestamp
       subject.should_receive(:[]=).with 'X-Slosilo-Signature', signature
       subject.sign!

--- a/spec/sequel_adapter_spec.rb
+++ b/spec/sequel_adapter_spec.rb
@@ -61,7 +61,7 @@ describe Slosilo::Adapters::SequelAdapter do
     before do
       Slosilo::encryption_key = Slosilo::Symmetric.new.random_key
       subject.unstub :create_model
-      Sequel::Model.cache_anonymous_models = false
+      Sequel.cache_anonymous_models = false
       Sequel::Model.db = db
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,3 +93,30 @@ end
 def rack_environment_with_input expected
   RackEnvironmentInputMatcher.new expected
 end
+
+class Object
+  def ergo
+    (block_given? && mapped = yield(self)) ? mapped : self
+  end
+end
+
+class Hash
+  def except *keys
+    dup.except! *keys
+  end
+  def except! *keys
+    tap{ keys.flatten.each{ |k| delete k } }
+  end
+  def compact
+    dup.compact!
+  end
+  def compact!
+    tap{ select!{|k,v| v} }
+  end
+end
+
+class NilClass
+  def ergo
+    nil
+  end
+end


### PR DESCRIPTION
This change is mostly to support caching of tokens by clients.  I've tried to keep it backwards compatible, but it definitely deserves a close look before moving it into production.
