### PR TITLE
Don't allow empty key ids in keystore

### DIFF
--- a/lib/slosilo/keystore.rb
+++ b/lib/slosilo/keystore.rb
@@ -7,7 +7,9 @@ module Slosilo
     end
     
     def put id, key
-      adapter.put_key id.to_s, key
+      id = id.to_s
+      fail ArgumentError, "id can't be empty" if id.empty?
+      adapter.put_key id, key
     end
     
     def get opts

--- a/spec/keystore_spec.rb
+++ b/spec/keystore_spec.rb
@@ -10,6 +10,14 @@ describe Slosilo::Keystore do
       adapter['test'].to_der.should == rsa.to_der
     end
 
+    it "refuses to store a key with a nil id" do
+      expect { subject.put(nil, key) }.to raise_error(ArgumentError)
+    end
+
+    it "refuses to store a key with an empty id" do
+      expect { subject.put('', key) }.to raise_error(ArgumentError)
+    end
+
     it "passes the Slosilo key to the adapter" do
       adapter.should_receive(:put_key).with "test", key
       subject.put :test, key


### PR DESCRIPTION
Fixes https://basecamp.com/1949725/projects/3987395-backlog/todos/64603406-slosilo-enroll
