### PR TITLE
Add Jenkins pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/Gemfile.lock
+/spec/reports

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,21 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent { label 'executor-v2' }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  stages {
+    stage('Test') {
+      steps {
+        sh './test.sh'
+
+        junit 'spec/reports/*.xml'
+      }
+    }
+
+  }
+}

--- a/lib/slosilo/key.rb
+++ b/lib/slosilo/key.rb
@@ -15,6 +15,10 @@ module Slosilo
       else
         OpenSSL::PKey::RSA.new 2048
       end
+    rescue OpenSSL::PKey::PKeyError => e
+      # old openssl versions used to report ArgumentError
+      # which arguably makes more sense here, so reraise as that
+      raise ArgumentError, e, e.backtrace
     end
     
     attr_reader :key

--- a/slosilo.gemspec
+++ b/slosilo.gemspec
@@ -1,5 +1,12 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/slosilo/version', __FILE__)
+begin
+  require File.expand_path('../lib/slosilo/version', __FILE__)
+rescue LoadError
+  # so that bundle can be run without the app code
+  module Slosilo
+    VERSION = '0.0.0'
+  end
+end
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Rafa\305\202 Rzepecki"]

--- a/slosilo.gemspec
+++ b/slosilo.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'io-grab', '~> 0.0.1'
   gem.add_development_dependency 'sequel' # for sequel tests
   gem.add_development_dependency 'sqlite3' # for sequel tests
+  gem.add_development_dependency 'activesupport' # for convenience in specs
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -14,8 +14,7 @@ describe Slosilo::Key do
 
       expect(tok.header).to eq \
         alg: 'conjur.org/slosilo/v2',
-        kid: key_fingerprint,
-        typ: 'JWT'
+        kid: key_fingerprint
       expect(tok.claims).to eq \
         iat: 1401938552,
         sub: 'host/example',
@@ -38,7 +37,7 @@ describe Slosilo::JWT do
     it 'allows conversion to JSON representation with #to_json' do
       json = JSON.load token.to_json
       expect(JSON.load Base64.urlsafe_decode64 json['protected']).to eq \
-          'alg' => 'test-sig', 'typ' => 'JWT'
+          'alg' => 'test-sig'
       expect(JSON.load Base64.urlsafe_decode64 json['payload']).to eq \
           'iat' => 1401938552, 'test' => 'token'
       expect(Base64.urlsafe_decode64 json['signature']).to eq signature
@@ -47,7 +46,7 @@ describe Slosilo::JWT do
     it 'allows conversion to compact representation with #to_s' do
       h, c, s = token.to_s.split '.'
       expect(JSON.load Base64.urlsafe_decode64 h).to eq \
-          'alg' => 'test-sig', 'typ' => 'JWT'
+          'alg' => 'test-sig'
       expect(JSON.load Base64.urlsafe_decode64 c).to eq \
           'iat' => 1401938552, 'test' => 'token'
       expect(Base64.urlsafe_decode64 s).to eq signature

--- a/spec/sequel_adapter_spec.rb
+++ b/spec/sequel_adapter_spec.rb
@@ -60,7 +60,7 @@ describe Slosilo::Adapters::SequelAdapter do
     let(:db) { Sequel.sqlite }
     before do
       allow(subject).to receive(:create_model).and_call_original
-      Sequel.cache_anonymous_models = false
+      Sequel::Model.cache_anonymous_models = false
       Sequel::Model.db = db
     end
   end

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -xe
+
+iid=slosilo-test-$(date +%s)
+
+docker build -t $iid -f - . << EOF
+  FROM ruby
+  WORKDIR /app
+  COPY Gemfile slosilo.gemspec ./
+  RUN bundle
+  COPY . ./
+  RUN bundle
+EOF
+
+cidfile=$(mktemp -u)
+docker run --cidfile $cidfile -v /app/spec/reports $iid bundle exec rake jenkins || :
+
+cid=$(cat $cidfile)
+
+docker cp $cid:/app/spec/reports spec/
+docker rm $cid
+
+# untag, will use cache next time if available but no junk will be left
+docker rmi $iid
+
+rm $cidfile


### PR DESCRIPTION
Adds a `test.sh` script which should work generically anywhere docker is available. JUnit reports get generated in specs/reports.

Then adds a trivial, Conjur-internal-Jenkins-specific Jenkinsfile on top of that.

Example: 
![screenshot-2017-10-17 jenkins cyberark--slosilo feature pipeline 5](https://user-images.githubusercontent.com/823636/31656540-1feb3b28-b32c-11e7-8bf0-32b17225233c.png)
(https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--slosilo/detail/feature%2Fpipeline/5/pipeline)

(Also fixed some small, unrelated issues I uncovered while working on that, so please DO NOT squash merge.)