### PR TITLE
add rake task which recalculates the fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.2.2
+
+* Add rake task `slosilo:recalculate_fingerprints` which rehashes the fingerprints in the keystore.
+**Note**: After migrating the slosilo keystore, run the above rake task to ensure the fingerprints are correctly hashed.
+
 # v2.2.1
 
 * Use SHA256 algorithm instead of MD5 for public key fingerprints.

--- a/lib/slosilo/adapters/sequel_adapter.rb
+++ b/lib/slosilo/adapters/sequel_adapter.rb
@@ -49,6 +49,13 @@ module Slosilo
         end
       end
 
+      def recalculate_fingerprints
+        model.each do |m|
+          m.update fingerprint: Slosilo::Key.new(m.key).fingerprint
+        end
+      end
+
+
       def migrate!
         unless fingerprint_in_db?
           model.db.transaction do
@@ -59,9 +66,7 @@ module Slosilo
             # reload the schema
             model.set_dataset model.dataset
 
-            model.each do |m|
-              m.update fingerprint: Slosilo::Key.new(m.key).fingerprint
-            end
+            recalculate_fingerprints
 
             model.db.alter_table :slosilo_keystore do
               set_column_not_null :fingerprint

--- a/lib/slosilo/version.rb
+++ b/lib/slosilo/version.rb
@@ -1,3 +1,3 @@
 module Slosilo
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/lib/tasks/slosilo.rake
+++ b/lib/tasks/slosilo.rake
@@ -24,4 +24,9 @@ namespace :slosilo do
   task :migrate => :environment do |t|
     Slosilo.adapter.migrate!
   end
+
+  desc "Recalculate fingerprints in keystore"
+  task :recalculate_fingerprints => :environment do |t|
+    Slosilo.adapter.recalculate_fingerprints
+  end
 end


### PR DESCRIPTION
This was needed due to the fact that in v2.2.1 the hashing algorithm that calculated these fingerprints was changed.

### What does this PR do?
- add rake task `slosilo:recalculate_fingerprints` which updates the fingerprints and guarantees the latest hashing algorithm is being used. 

### What ticket does this PR close?
#21 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation