### PR TITLE
replace label 'releaser-v2' with 'executor-v2'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     }
 
     stage('Publish to RubyGems') {
-      agent { label 'releaser-v2' }
+      agent { label 'executor-v2' }
       when {
         allOf {
           branch 'master'


### PR DESCRIPTION
Currently there no agents labeled with releaser-v2.

### What does this PR do?
replaces agent labeled with `releaser-v2` to `executor-v2`

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation