### PR TITLE
Bulk update fingerprints

### DIFF
--- a/lib/slosilo/adapters/sequel_adapter.rb
+++ b/lib/slosilo/adapters/sequel_adapter.rb
@@ -50,8 +50,12 @@ module Slosilo
       end
 
       def recalculate_fingerprints
-        model.each do |m|
-          m.update fingerprint: Slosilo::Key.new(m.key).fingerprint
+        # Use a transaction to ensure that all fingerprints are updated together. If any update fails,
+        # we want to rollback all updates.
+        model.db.transaction do
+          model.each do |m|
+            m.update fingerprint: Slosilo::Key.new(m.key).fingerprint
+          end
         end
       end
 


### PR DESCRIPTION
### What does this PR do?
Ensures that there will never be a mix of old and new keys when running the rake task `slosilo:recalculate_fingerprints`. DB transactions are re-entrant so there is no issue calling `recalculate_fingerprints` within `migrate!`

Adds deprecation warning for the method `migrate!`

### What ticket does this PR close?
Connected to #22 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation