### PR TITLE
ONYX-14080: Bump to V3.0.0 with Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.0.0
+
+* Transition to Ruby 3. Consuming projects based on Ruby 2 shall use slosilo V2.X.X.
+
 # v2.2.2
 
 * Add rake task `slosilo:recalculate_fingerprints` which rehashes the fingerprints in the keystore.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ And then execute:
 
 ## Compatibility
 
+Version 3.0 introduced full transition to Ruby 3.
+Consumers who use slosilo in Ruby 2 projects, shall use slosilo V2.X.X.
+
 Version 2.0 introduced new symmetric encryption scheme using AES-256-GCM
 for authenticated encryption. It allows you to provide AAD on all symmetric
 encryption primitives. It's also **NOT COMPATIBLE** with CBC used in version <2.

--- a/lib/slosilo/attr_encrypted.rb
+++ b/lib/slosilo/attr_encrypted.rb
@@ -26,7 +26,10 @@ module Slosilo
         aad = options[:aad]
         # note nil.to_s is "", which is exactly the right thing
         auth_data = aad.respond_to?(:to_proc) ? aad.to_proc : proc{ |_| aad.to_s }
-        raise ":aad proc must take one argument" unless auth_data.arity.abs == 1 # take abs to allow *args arity, -1
+
+        # In ruby 3 .arity for #proc returns both 1 and 2, depends on internal #proc
+        # This method is also being called with aad which is string, in such case the arity is 1
+        raise ":aad proc must take two arguments" unless (auth_data.arity.abs == 2 || auth_data.arity.abs == 1)
 
         # push a module onto the inheritance hierarchy
         # this allows calling super in classes

--- a/lib/slosilo/version.rb
+++ b/lib/slosilo/version.rb
@@ -1,3 +1,3 @@
 module Slosilo
-  VERSION = "2.2.2"
+  VERSION = "3.0.0"
 end

--- a/slosilo.gemspec
+++ b/slosilo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.name          = "slosilo"
   gem.require_paths = ["lib"]
   gem.version       = Slosilo::VERSION
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 3.0.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/sequel_adapter_spec.rb
+++ b/spec/sequel_adapter_spec.rb
@@ -30,13 +30,13 @@ describe Slosilo::Adapters::SequelAdapter do
   describe "#put_key" do
     let(:id) { "id" }
     it "creates the key" do
-      expect(model).to receive(:create).with id: id, key: key.to_der
+      expect(model).to receive(:create).with(hash_including(:id => id, :key => key.to_der))
       allow(model).to receive_messages columns: [:id, :key]
       subject.put_key id, key
     end
 
     it "adds the fingerprint if feasible" do
-      expect(model).to receive(:create).with id: id, key: key.to_der, fingerprint: key.fingerprint
+      expect(model).to receive(:create).with(hash_including(:id => id, :key => key.to_der, :fingerprint => key.fingerprint))
       allow(model).to receive_messages columns: [:id, :key, :fingerprint]
       subject.put_key id, key
     end

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 iid=slosilo-test-$(date +%s)
 
 docker build -t $iid -f - . << EOF
-  FROM ruby
+  FROM ruby:3.0
   WORKDIR /app
   COPY Gemfile slosilo.gemspec ./
   RUN bundle


### PR DESCRIPTION
### Desired Outcome

slosilo can work with Ruby V3. [consumed in projects with ruby 3]
This is a breaking change, consuming it in projects using ruby 2 might cause unexpected behavior.

### Implemented Changes

There was a change in ruby-3.0.2 implementation the results symbol#proc arity to return 2, instead of 1 in ruby-2.x.x.
You can read more in this thread:
https://stackoverflow.com/questions/70096114/proc-arity-in-ruby-3-0-2-vs-ruby-2-x-x

### Connected Issue/Story

CyberArk internal issue link: [14080](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14080)

### Definition of Done

slosilo works with ruby v3.0.2.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
