### PR TITLE
Fix thread safety issue in Symmetric cipher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.0.1
+
+ * The symmetric cipher class now encrypts and decrypts in a thread-safe manner.
+   [cyberark/slosilo#31](https://github.com/cyberark/slosilo/pull/31)
+
 # v3.0.0
 
 * Transition to Ruby 3. Consuming projects based on Ruby 2 shall use slosilo V2.X.X.

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM ruby
+
+COPY ./ /src/
+
+WORKDIR /src
+
+RUN bundle

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  dev:
+    build:
+      context: ..
+      dockerfile: dev/Dockerfile.dev
+    volumes:
+      - ../:/src

--- a/lib/slosilo/symmetric.rb
+++ b/lib/slosilo/symmetric.rb
@@ -5,6 +5,7 @@ module Slosilo
 
     def initialize
       @cipher = OpenSSL::Cipher.new 'aes-256-gcm' # NB: has to be lower case for whatever reason.
+      @cipher_mutex = Mutex.new
     end
 
     # This lets us do a final sanity check in migrations from older encryption versions
@@ -13,14 +14,18 @@ module Slosilo
     end
 
     def encrypt plaintext, opts = {}
-      @cipher.reset
-      @cipher.encrypt
-      @cipher.key = (opts[:key] or raise("missing :key option"))
-      @cipher.iv = iv = random_iv
-      @cipher.auth_data = opts[:aad] || "" # Nothing good happens if you set this to nil, or don't set it at all
-      ctext = @cipher.update(plaintext) + @cipher.final
-      tag = @cipher.auth_tag(TAG_LENGTH)
-      "#{VERSION_MAGIC}#{tag}#{iv}#{ctext}"
+      # All of these operations in OpenSSL must occur atomically, so we
+      # synchronize their access to make this step thread-safe.
+      @cipher_mutex.synchronize do
+        @cipher.reset
+        @cipher.encrypt
+        @cipher.key = (opts[:key] or raise("missing :key option"))
+        @cipher.iv = iv = random_iv
+        @cipher.auth_data = opts[:aad] || "" # Nothing good happens if you set this to nil, or don't set it at all
+        ctext = @cipher.update(plaintext) + @cipher.final
+        tag = @cipher.auth_tag(TAG_LENGTH)
+        "#{VERSION_MAGIC}#{tag}#{iv}#{ctext}"
+      end
     end
 
     def decrypt ciphertext, opts = {}
@@ -28,19 +33,23 @@ module Slosilo
 
       raise "Invalid version magic: expected #{VERSION_MAGIC} but was #{version}" unless version == VERSION_MAGIC
 
-      @cipher.reset
-      @cipher.decrypt
-      @cipher.key = opts[:key]
-      @cipher.iv = iv
-      @cipher.auth_tag = tag
-      @cipher.auth_data = opts[:aad] || ""
-      @cipher.update(ctext) + @cipher.final
+      # All of these operations in OpenSSL must occur atomically, so we
+      # synchronize their access to make this step thread-safe.
+      @cipher_mutex.synchronize do
+        @cipher.reset
+        @cipher.decrypt
+        @cipher.key = opts[:key]
+        @cipher.iv = iv
+        @cipher.auth_tag = tag
+        @cipher.auth_data = opts[:aad] || ""
+        @cipher.update(ctext) + @cipher.final
+      end
     end
-    
+
     def random_iv
       @cipher.random_iv
     end
-    
+
     def random_key
       @cipher.random_key
     end

--- a/lib/slosilo/version.rb
+++ b/lib/slosilo/version.rb
@@ -1,3 +1,3 @@
 module Slosilo
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is to allow thread-safe use of the Symmetric cipher class.

### Implemented Changes

This PR adds a synchronization mutex to the Symmetric class to manage thread
access to the critical portions of OpenSSL encryption and decryption.

Previously, if this steps were allowed to interleave among threads, it would corrupt
the OpenSSL state, leading to intermittent CipherErrors from OpenSSL.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-479

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
