### PR TITLE
Don't run git in a docker container

### DIFF
--- a/publish-rubygem.sh
+++ b/publish-rubygem.sh
@@ -2,10 +2,10 @@
 
 docker pull registry.tld/conjurinc/publish-rubygem
 
-docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd
+git clean -fxd
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
   registry.tld/conjurinc/publish-rubygem slosilo
 
-docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd
+git clean -fxd


### PR DESCRIPTION
This PR updates the publish script to not run `git` in a Docker container. `git` is available on the Jenkins nodes, there's
no need to run it in a container.
